### PR TITLE
Update express-fileupload dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "micro-upload",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "A express-fileupload wrapper for micro",
   "main": "index.js",
   "scripts": {
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/julianduque/micro-upload#readme",
   "dependencies": {
-    "express-fileupload": "^0.1.2"
+    "express-fileupload": "^1.1.5"
   }
 }


### PR DESCRIPTION
Hi, I was using this module but then I noticed that express-fileupload was super outdated. This PR updates it to the latest version, as well as bumping this package up a major version because of the breaking change.